### PR TITLE
modify/#151/FE 로그인 리다이렉트 url 변경

### DIFF
--- a/src/app/(user)/messages/components/AllMessageFilter.stories.tsx
+++ b/src/app/(user)/messages/components/AllMessageFilter.stories.tsx
@@ -1,5 +1,5 @@
-import { filterItems } from '@/app/(user)/messages/page';
 import type { Meta, StoryObj } from '@storybook/react';
+import { filterItems } from '@/types/message';
 import { AllMessageFilter } from './AllMessageFilter';
 
 const meta = {

--- a/src/app/(user)/messages/page.tsx
+++ b/src/app/(user)/messages/page.tsx
@@ -10,28 +10,7 @@ import { AllMessageSearchBar } from '@/app/(user)/messages/components/AllMessage
 import { MessageContent } from '@/app/(user)/messages/components/MessageContent';
 import { MessageHeader } from '@/app/(user)/messages/components/MessageHeader';
 import { MessageInput } from '@/app/(user)/messages/components/MessageInput';
-import { FilterItem } from '@/types/message';
-import { BsSuitcaseLg } from 'react-icons/bs';
-import { BsChatSquare } from 'react-icons/bs';
-import { FaAirbnb } from 'react-icons/fa';
-
-export const filterItems = [
-  {
-    id: 1,
-    label: '전체',
-    icon: BsChatSquare,
-  },
-  {
-    id: 2,
-    label: '여행',
-    icon: BsSuitcaseLg,
-  },
-  {
-    id: 3,
-    label: '지원',
-    icon: FaAirbnb,
-  },
-] as const satisfies FilterItem[];
+import { filterItems } from '@/types/message';
 
 export default function Messages() {
   const [showReservation, setShowReservation] = useState<boolean>(true);

--- a/src/app/(user)/wishlists/page.tsx
+++ b/src/app/(user)/wishlists/page.tsx
@@ -1,4 +1,3 @@
-import Image from 'next/image';
 import { RecentlyViewedCard } from '@/app/(user)/wishlists/components/RecentlyViewedCard';
 import { WishlistsCard } from '@/app/(user)/wishlists/components/WishlistsCard';
 

--- a/src/components/common/Header/UserMenuItem.tsx
+++ b/src/components/common/Header/UserMenuItem.tsx
@@ -1,5 +1,7 @@
 import { signOut } from 'next-auth/react';
 import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+import { ROUTES } from '@/constants/routeURL';
 
 interface UserMenuItemProps {
   id: string;
@@ -9,13 +11,30 @@ interface UserMenuItemProps {
   onToggleOpen: () => void;
 }
 
-export default function UserMenuItem({ id, label, hasDivider, href, onToggleOpen }: UserMenuItemProps) {
+export default function UserMenuItem({
+  id,
+  label,
+  hasDivider,
+  href,
+  onToggleOpen,
+}: UserMenuItemProps) {
+  const pathname = usePathname();
+
+  // 로그인, 회원가입 메뉴 이동시 url 쿠키에 저장
+  const handleLogin = () => {
+    if (!pathname.includes(ROUTES.LOGIN)) {
+      document.cookie = `prevPath=${pathname};max-age=${60 * 30};path=/`;
+    }
+    onToggleOpen();
+  };
+
+  // 로그아웃 로직
   const handleClick = async () => {
     switch (id) {
       case 'logout':
         // 로그아웃 처리
         try {
-          await signOut();
+          await signOut({ redirectTo: ROUTES.HOME });
         } catch (error) {
           console.error('로그아웃 중 오류가 발생했습니다:', error);
         }
@@ -30,8 +49,25 @@ export default function UserMenuItem({ id, label, hasDivider, href, onToggleOpen
   return (
     <>
       {href ? (
-        <Link href={href} onClick={onToggleOpen}>{content}</Link>
+        href === '/signin' ? (
+          // 로그인, 회원 가입 메뉴
+          <Link
+            href={href}
+            onClick={handleLogin}
+          >
+            {content}
+          </Link>
+        ) : (
+          // href 있는 메뉴
+          <Link
+            href={href}
+            onClick={onToggleOpen}
+          >
+            {content}
+          </Link>
+        )
       ) : (
+        // href 없는 메뉴
         <button
           onClick={handleClick}
           className="w-full text-left"

--- a/src/types/message.ts
+++ b/src/types/message.ts
@@ -1,7 +1,28 @@
-import { IconType } from "react-icons";
+import { IconType } from 'react-icons';
+import { BsSuitcaseLg } from 'react-icons/bs';
+import { BsChatSquare } from 'react-icons/bs';
+import { FaAirbnb } from 'react-icons/fa';
 
 export interface FilterItem {
   id: number;
   label: string;
   icon: IconType;
 }
+
+export const filterItems = [
+  {
+    id: 1,
+    label: '전체',
+    icon: BsChatSquare,
+  },
+  {
+    id: 2,
+    label: '여행',
+    icon: BsSuitcaseLg,
+  },
+  {
+    id: 3,
+    label: '지원',
+    icon: FaAirbnb,
+  },
+] as const satisfies FilterItem[];


### PR DESCRIPTION
# 제목
modify/#151/FE 로그인 리다이렉트 url 변경
### 이슈 번호 : #151

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- 로그인 및 회원가입 메뉴 항목에서 현재 경로를 쿠키에 저장하는 기능 추가.
	- 필터 아이템을 정의하는 새로운 상수 `filterItems` 추가.

- **Bug Fixes**
	- 리디렉션 URL을 쿠키 값을 기반으로 동적으로 설정하도록 수정.

- **Refactor**
	- 여러 컴포넌트에서 `filterItems`의 소스를 변경하여 코드 구조 개선.
	- `Messages` 컴포넌트에서 로컬 필터 아이템 선언 제거.

- **Chores**
	- 불필요한 `Image` 컴포넌트의 import 문 제거.
	- `react-icons` 라이브러리의 import 문 형식 변경.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->