### PR TITLE
[#145] test: useModal test 추가, fix: filter any 타입 수정

### DIFF
--- a/src/app/(header-footer)/components/filter/FilterModal.tsx
+++ b/src/app/(header-footer)/components/filter/FilterModal.tsx
@@ -36,7 +36,10 @@ export default function FilterModal() {
 
   const [filter, setFilter] = useState<FilterType>(paramFilter);
 
-  const handleFilter = (newState: any, type: keyof FilterType) => {
+  const handleFilter = <K extends keyof FilterType>(
+    newState: FilterType[K],
+    type: keyof FilterType,
+  ) => {
     setFilter((prev) => ({ ...prev, [type]: newState }));
   };
 

--- a/src/hooks/useModal.test.ts
+++ b/src/hooks/useModal.test.ts
@@ -1,0 +1,110 @@
+import { act, renderHook } from '@testing-library/react';
+import { useDispatch, useSelector } from 'react-redux';
+import { ModalIdType, useModal } from '@/hooks/useModal';
+
+// useDispatch, useSelector 모킹
+jest.mock('react-redux', () => ({
+  useDispatch: jest.fn(),
+  useSelector: jest.fn(),
+}));
+
+//
+
+describe('useModal test', () => {
+  const mockDispatch = jest.fn();
+
+  const modalId = 'room-filter-modal';
+  const anotherModalId = 'room-amenities-modal';
+
+  // beforeEach에서 모킹된 함수들을 초기화
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useDispatch as unknown as jest.Mock).mockReturnValue(mockDispatch);
+  });
+
+  test('초기 렌더링 시 modalState가 false인지 확인', () => {
+    (useSelector as unknown as jest.Mock).mockReturnValue(false);
+
+    // useModal 훅을 렌더링
+    const { result } = renderHook(() => useModal(modalId));
+
+    // 초기값이 false인지 확인
+    expect(result.current.modalState).toBe(false);
+  });
+
+  test('handleOpenModal 함수를 호출하면 dispatch가 openModal을 호출하고, modalState가 true인지 확인', () => {
+    (useSelector as unknown as jest.Mock).mockReturnValue(false);
+
+    // useModal 훅을 렌더링
+    const { result } = renderHook(() => useModal(modalId));
+
+    // handleOpenModal 함수 호출, act를 사용해 비동기 처리
+    act(() => {
+      result.current.handleOpenModal();
+    });
+
+    // openModal이 dispatch 되었는지 확인
+    expect(mockDispatch).toHaveBeenCalledWith({
+      type: 'modal/openModal',
+      payload: modalId,
+    });
+
+    // modalState가 true인지 확인
+    expect(result.current.modalState).toBe(true);
+  });
+
+  test('handleCloseModal 함수를 호출하면 dispatch가 closeModal을 호출하고, modalState가 false인지 확인', () => {
+    (useSelector as unknown as jest.Mock).mockReturnValue(false);
+
+    // useModal 훅을 렌더링
+    const { result } = renderHook(() => useModal(modalId));
+
+    // handleCloseModal 함수 호출, act를 사용해 비동기 처리
+    act(() => {
+      result.current.handleCloseModal();
+    });
+
+    // closeModal이 dispatch 되었는지 확인
+    expect(mockDispatch).toHaveBeenCalledWith({
+      type: 'modal/closeModal',
+    });
+
+    // modalState가 false인지 확인
+    expect(result.current.modalState).toBe(false);
+  });
+
+  test('현재 모달이 열려있을 때, 다른 모달은 닫혀있어야한다.', () => {
+    // 모달이 열려있는 상태로 설정
+    (useSelector as unknown as jest.Mock).mockImplementation((selector) =>
+      selector({
+        modal: {
+          modalState: true,
+          modalId: modalId,
+        },
+      }),
+    );
+
+    // useModal 훅을 렌더링
+    const { result } = renderHook(() => useModal(anotherModalId));
+
+    // 현재 모달이 열려있을 때, 다른 모달이 닫혀있는지 확인
+    expect(result.current.modalState).toBe(false);
+  });
+
+  test('잘못된 modalId를 사용했을 때, 모달 상태는 false여야 한다.', () => {
+    (useSelector as unknown as jest.Mock).mockImplementation((selector) =>
+      selector({
+        modal: {
+          modalState: false,
+          modalId: null,
+        },
+      }),
+    );
+
+    // 잘못된 modalId로 useModal 훅을 렌더링
+    const { result } = renderHook(() => useModal('wrong-modal-id' as ModalIdType));
+
+    // 모달이 닫혀있는지 확인
+    expect(result.current.modalState).toBe(false);
+  });
+});


### PR DESCRIPTION
# 제목
test: useModal test 추가, fix: filter any 타입 수정

### 이슈 번호 : #145 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **타입 안전성**
	- 필터 모달의 타입 처리 방식을 개선하여 더욱 안전한 상태 관리 지원

- **테스트**
	- `useModal` 훅에 대한 포괄적인 단위 테스트 추가
	- 모달 상태 관리의 다양한 시나리오 검증
	- 모달 열기/닫기 기능의 안정성 확인

<!-- end of auto-generated comment: release notes by coderabbit.ai -->