### PR TITLE
feat : 숙소 예약 생성시 예약가능조회 캐시 무효화

### DIFF
--- a/src/apis/reservation/actions.test.ts
+++ b/src/apis/reservation/actions.test.ts
@@ -1,9 +1,16 @@
+import { revalidateTag } from 'next/cache';
 import { auth } from '@/auth';
 import { createReservation } from '@/apis/reservation/actions';
+import { CACHE_TAGS } from '@/constants/cacheTags';
 
 // @/auth의 auth를 모킹
 jest.mock('@/auth', () => ({
   auth: jest.fn(),
+}));
+
+// revalidateTag 모킹
+jest.mock('next/cache', () => ({
+  revalidateTag: jest.fn(),
 }));
 
 describe('Reservation Action Test', () => {
@@ -27,6 +34,8 @@ describe('Reservation Action Test', () => {
 
       expect(result.success).toBe(true);
       expect(result.status).toBe(201);
+      expect(revalidateTag).toHaveBeenCalledTimes(1);
+      expect(revalidateTag).toHaveBeenCalledWith(CACHE_TAGS.ROOMS.AVAILABLE(validInput.roomId));
       // 응답에 data 객체가 존재하는지 확인
       expect(result.data).toBeDefined();
       // data 객체 안에 orderNumber가 있는지 확인

--- a/src/apis/reservation/actions.ts
+++ b/src/apis/reservation/actions.ts
@@ -1,10 +1,12 @@
 'use server';
 
+import { revalidateTag } from 'next/cache';
 import { auth } from '@/auth';
 import { CreateReservationInput } from '@/schemas/reservation';
 import { ActionResponse } from '@/types/action';
 import { CreateReservationResponse } from '@/types/reservation';
 import { httpClient } from '@/apis/core/httpClient';
+import { CACHE_TAGS } from '@/constants/cacheTags';
 
 /**
  * 예약을 생성하는 서버 액션입니다.
@@ -36,6 +38,9 @@ export async function createReservation(
         status: response.status,
       };
     }
+
+    revalidateTag(CACHE_TAGS.ROOMS.AVAILABLE(input.roomId));
+
     // 성공 시 응답
     return {
       success: true,

--- a/src/apis/reviews/queries.test.ts
+++ b/src/apis/reviews/queries.test.ts
@@ -17,6 +17,21 @@ describe('Reviews Query Test', () => {
       const result = await getReviews(1);
       expect(result).toEqual(mockReview);
     });
+
+    test('파라미터로 올바른 URL 요청을 보낸다', async () => {
+      let result = await getReviews(1, undefined, undefined, 'low');
+      expect(result).toEqual(mockReview);
+
+      result = await getReviews(1, undefined, 10);
+      expect(result).toEqual(mockReview);
+
+      result = await getReviews(1, 2, 10);
+      expect(result).toEqual(mockReview);
+
+      result = await getReviews(1);
+      expect(result).toEqual(mockReview);
+    });
+
     test('존재하지 않는 방일 경우 notFound를 호출한다.', async () => {
       await expect(getReviews(404)).rejects.toThrow();
       expect(notFound).toHaveBeenCalled();

--- a/src/apis/reviews/queries.ts
+++ b/src/apis/reviews/queries.ts
@@ -32,13 +32,16 @@ export async function getReviews(
   options?: { next?: NextFetchRequestConfig },
 ): Promise<GetReviewsResponse> {
   try {
-    const queryParams = new URLSearchParams();
+    let queryParams;
+    if (page || limit || sortType) {
+      // 파라미터가 하나라도 있을 때만 생성
+      queryParams = new URLSearchParams();
+      if (page) queryParams.append('page', String(page));
+      if (limit) queryParams.append('limit', String(limit));
+      if (sortType) queryParams.append('sort', sortType);
+    }
 
-    if (page) queryParams.append('page', String(page));
-    if (limit) queryParams.append('limit', String(limit));
-    if (sortType) queryParams.append('sort', sortType);
-
-    const queryString = queryParams.toString();
+    const queryString = queryParams?.toString();
     const url = `/rooms/${roomId}/reviews${queryParams ? `?${queryString}` : ''}`;
 
     const response = await httpClient.get<GetReviewsResponse>(url, options);


### PR DESCRIPTION
# 제목
숙소 예약 생성시 예약가능조회 캐시 무효화
### 이슈 번호 : #231 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
	- 예약 생성 시 캐시 무효화 기능 추가
	- 리뷰 조회 함수의 쿼리 파라미터 처리 개선

- **테스트**
	- 예약 및 리뷰 관련 테스트 케이스 확장
	- 다양한 시나리오에 대한 테스트 커버리지 향상

- **성능 최적화**
	- 쿼리 파라미터 생성 로직 최적화
	- 불필요한 쿼리 파라미터 생성 방지

<!-- end of auto-generated comment: release notes by coderabbit.ai -->