### PR TITLE
refactor/#235/FE-httpclient-분리

### DIFF
--- a/src/apis/reservation/actions.ts
+++ b/src/apis/reservation/actions.ts
@@ -5,7 +5,7 @@ import { auth } from '@/auth';
 import { CreateReservationInput } from '@/schemas/reservation';
 import { ActionResponse } from '@/types/action';
 import { CreateReservationResponse } from '@/types/reservation';
-import { httpClient } from '@/apis/core/httpClient';
+import { authHttpClient } from '@/apis/core/httpClient';
 import { CACHE_TAGS } from '@/constants/cacheTags';
 
 /**
@@ -28,7 +28,7 @@ export async function createReservation(
     }
 
     // API 요청
-    const response = await httpClient.post<CreateReservationResponse>('/reservation', input);
+    const response = await authHttpClient.post<CreateReservationResponse>('/reservation', input);
 
     // API에서 명시적으로 처리되는 에러
     if (!response.success) {

--- a/src/apis/reservation/queries.ts
+++ b/src/apis/reservation/queries.ts
@@ -1,7 +1,7 @@
 import { notFound } from 'next/navigation';
 import { CustomError } from '@/errors';
 import { Reservation } from '@/types/reservation';
-import { httpClient } from '@/apis/core/httpClient';
+import { authHttpClient } from '@/apis/core/httpClient';
 
 /**
  * 특정 예약 정보를 조회합니다.
@@ -10,7 +10,7 @@ import { httpClient } from '@/apis/core/httpClient';
  */
 export async function getReservation(orderNumber: string): Promise<Reservation> {
   try {
-    const response = await httpClient.get<Reservation>(`/reservation/${orderNumber}`);
+    const response = await authHttpClient.get<Reservation>(`/reservation/${orderNumber}`);
 
     if (!response.success) {
       switch (response.status) {

--- a/src/apis/reviews/actions.ts
+++ b/src/apis/reviews/actions.ts
@@ -4,7 +4,7 @@ import { revalidateTag } from 'next/cache';
 import { auth } from '@/auth';
 import { CreateReviewInput, UpdateReviewInput } from '@/schemas';
 import { ActionResponse } from '@/types/action';
-import { httpClient } from '@/apis/core/httpClient';
+import { authHttpClient } from '@/apis/core/httpClient';
 import { CACHE_TAGS } from '@/constants/cacheTags';
 
 /**
@@ -28,7 +28,7 @@ export async function createReview(
       };
     }
     // API 요청
-    const response = await httpClient.post<null>(`/rooms/${roomId}/reviews`, formData);
+    const response = await authHttpClient.post<null>(`/rooms/${roomId}/reviews`, formData);
     // API에서 명시적으로 처리되는 에러
     if (!response.success) {
       return {
@@ -77,7 +77,7 @@ export async function deleteReview(roomId: number, reviewId: number): Promise<Ac
     }
 
     // API 요청
-    const response = await httpClient.delete<null>(`/rooms/${roomId}/reviews/${reviewId}`);
+    const response = await authHttpClient.delete<null>(`/rooms/${roomId}/reviews/${reviewId}`);
 
     // API에서 명시적으로 처리되는 에러
     if (!response.success) {
@@ -131,7 +131,10 @@ export async function updateReview(
       };
     }
     // API 요청
-    const response = await httpClient.patch<null>(`/rooms/${roomId}/reviews/${reviewId}`, formData);
+    const response = await authHttpClient.patch<null>(
+      `/rooms/${roomId}/reviews/${reviewId}`,
+      formData,
+    );
 
     // API에서 명시적으로 처리되는 에러
     if (!response.success) {

--- a/src/apis/reviews/queries.ts
+++ b/src/apis/reviews/queries.ts
@@ -1,7 +1,7 @@
 import { notFound } from 'next/navigation';
 import { CustomError } from '@/errors';
 import { ReviewSortType, ReviewSummarize } from '@/types/review';
-import { httpClient } from '@/apis/core/httpClient';
+import { authHttpClient, httpClient } from '@/apis/core/httpClient';
 import { CACHE_TAGS } from '@/constants/cacheTags';
 
 export interface GetReviewsResponse {
@@ -84,7 +84,7 @@ export async function getReviews(
  */
 export async function getReviewAvailable(roomId: number): Promise<string[]> {
   try {
-    const response = await httpClient.get<string[]>(`/rooms/${roomId}/reviews/available`, {
+    const response = await authHttpClient.get<string[]>(`/rooms/${roomId}/reviews/available`, {
       next: {
         tags: [CACHE_TAGS.REVIEWS.AVAILABLE(roomId)],
       },

--- a/src/apis/rooms/actions.ts
+++ b/src/apis/rooms/actions.ts
@@ -3,7 +3,7 @@
 import { revalidateTag } from 'next/cache';
 import { auth } from '@/auth';
 import { ActionResponse } from '@/types/action';
-import { httpClient } from '@/apis/core/httpClient';
+import { authHttpClient } from '@/apis/core/httpClient';
 import { CACHE_TAGS } from '@/constants/cacheTags';
 
 /**
@@ -22,7 +22,7 @@ export async function createScrap(roomId: number): Promise<ActionResponse> {
       };
     }
 
-    const response = await httpClient.post<null>(`/rooms/${roomId}/scrap`);
+    const response = await authHttpClient.post<null>(`/rooms/${roomId}/scrap`);
 
     if (!response.success) {
       return {
@@ -64,7 +64,7 @@ export async function deleteScrap(roomId: number): Promise<ActionResponse> {
       };
     }
 
-    const response = await httpClient.delete(`/rooms/${roomId}/scrap`);
+    const response = await authHttpClient.delete(`/rooms/${roomId}/scrap`);
 
     if (!response.success) {
       return {

--- a/src/apis/rooms/queries.ts
+++ b/src/apis/rooms/queries.ts
@@ -1,7 +1,7 @@
 import { notFound } from 'next/navigation';
 import { CustomError } from '@/errors';
 import { Room } from '@/types/room';
-import { httpClient } from '@/apis/core/httpClient';
+import { authHttpClient, httpClient } from '@/apis/core/httpClient';
 import { CACHE_TAGS } from '@/constants/cacheTags';
 
 /**
@@ -48,7 +48,7 @@ export async function getRoom(roomId: number): Promise<Room> {
  */
 export async function getScrap(roomId: number): Promise<boolean> {
   try {
-    const response = await httpClient.get<boolean>(`/rooms/${roomId}/scrap`, {
+    const response = await authHttpClient.get<boolean>(`/rooms/${roomId}/scrap`, {
       next: {
         tags: [CACHE_TAGS.ROOMS.SCRAP(roomId)],
       },


### PR DESCRIPTION
# 제목
httpclient-분리
### 이슈 번호 : #235 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리즈 노트

- **새로운 기능**
  - 인증된 HTTP 클라이언트 도입으로 API 요청의 보안 강화

- **개선 사항**
  - 예약, 리뷰, 객실 관련 API 요청에 대한 인증 메커니즘 업데이트
  - HTTP 클라이언트의 접근 제어자 수정으로 더 유연한 확장성 제공

- **기술적 변경**
  - 기존 HTTP 클라이언트에서 인증 HTTP 클라이언트로 전환
  - 쿠키 및 인증 헤더 처리 방식 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->